### PR TITLE
Rebase `v0.10.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.22.0 AS builder
+FROM golang:1.22.6 AS builder
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Bumps golang from 1.22.0 to 1.22.6.

**What this PR does / why we need it**:
This PR cherry-picks all necessary changes by the source repository of the version `v0.10.0`.


